### PR TITLE
Set the ADV_HOST in the connect-avro-distributed.properties file

### DIFF
--- a/setup-and-run.sh
+++ b/setup-and-run.sh
@@ -103,7 +103,7 @@ if [[ ! -z "${ADV_HOST}" ]]; then
     echo -e "\nadvertised.listeners=PLAINTEXT://${ADV_HOST}:$BROKER_PORT" \
          >> /opt/confluent/etc/kafka/server.properties
     echo -e "\nrest.advertised.host.name=${ADV_HOST}" \
-         >> /opt/confluent/etc/kafka/connect-distributed.properties
+         >> /opt/confluent/etc/schema-registry/connect-avro-distributed.properties
     sed -e 's#localhost#'"${ADV_HOST}"'#g' -i /usr/share/landoop/kafka-tests.yml /var/www/env.js /etc/supervisord.conf
 fi
 


### PR DESCRIPTION
setup-and-run.sh sets a property in the non-avro connect configuration file (/opt/confluent/etc/kafka/connect-distributed.properties).  This has been fixed to refer to the avro configuration file.