### PR TITLE
Add bootstrap.servers configuration for kafka-rest.properties

### DIFF
--- a/setup-and-run.sh
+++ b/setup-and-run.sh
@@ -66,6 +66,7 @@ schema.registry.url=http://localhost:$REGISTRY_PORT
 zookeeper.connect=localhost:$ZK_PORT
 # fix for Kafka REST consumer issues
 consumer.request.timeout.ms=30000
+bootstrap.servers=PLAINTEXT://localhost:$BROKER_PORT
 EOF
 
 ## Schema Registry specific


### PR DESCRIPTION
I added the this configuration because I was having problem with Kafka Topic UI, when using non standard port for broker.
This configuration is describe here https://github.com/Landoop/kafka-topics-ui on Common Issues part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/fast-data-dev/57)
<!-- Reviewable:end -->
