### PR TITLE
Fix directory creation when /tmp/certs exists

### DIFF
--- a/setup-and-run.sh
+++ b/setup-and-run.sh
@@ -337,7 +337,7 @@ if [[ $ENABLE_SSL =~ $TRUE_REG ]]; then
     else
         echo -e "\e[92mCreating CA and key-cert pairs.\e[34m"
         {
-            mkdir /tmp/certs
+            mkdir -p /tmp/certs
             pushd /tmp/certs
             # Create Landoop Fast Data Dev CA
             quickcert -ca -out lfddca. -CN "Landoop's Fast Data Dev Self Signed Certificate Authority"


### PR DESCRIPTION
We've had issues when trying to keep the keystore on a docker volume.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/fast-data-dev/68)
<!-- Reviewable:end -->
