### PR TITLE
Configure automatically lenses-cli at first login

### DIFF
--- a/filesystem/usr/local/share/landoop/etc/bashrc
+++ b/filesystem/usr/local/share/landoop/etc/bashrc
@@ -6,19 +6,20 @@ alias ls='ls --color=auto'
 # set env variables and set defaults
 WEB_PORT=${WEB_PORT:-3030}
 ZK_PORT=${ZK_PORT:-2181}
-DEBUG=${DEBUG:-0}
+USER=${USER:-admin}
+LEN_PASSWORD=${PASSWORD:-admin}
 
 # check the status of zookeeper to provided $ZK_PORT
 ZK_STATUS="$(echo ruok | nc localhost $ZK_PORT | grep imok)"
 
 # Preconfigure lenses-cli
-for ((i=0;i<60;i++)); do
-    sleep 1
-    if [[  -n "$ZK_STATUS" ]]; then
-        if [[ ! -f $HOME/.lenses/lenses-cli.yml ]] && [[ -n $USER ]] && [[ -n $PASSWORD ]]; then
-            echo -e "lenses-cli configured"
-            lenses-cli configure --debug=$DEBUG --user=$USER  --pass=$PASSWORD --host=http://127.0.0.1:${WEB_PORT}
+if echo ruok | nc localhost $ZK_PORT | grep -sq imok; then
+        if [[ ! -f $HOME/.lenses/lenses-cli.yml ]]; then
+            echo -e "First login. Configuring lenses-cli."
+            lenses-cli configure \
+                       --user="$USER" \
+                       --pass="$LEN_PASSWORD" \
+                       --default-location \
+                       --host=http://127.0.0.1:${WEB_PORT}
         fi
-        break
-    fi
-done
+fi

--- a/filesystem/usr/local/share/landoop/etc/bashrc
+++ b/filesystem/usr/local/share/landoop/etc/bashrc
@@ -2,3 +2,23 @@ export PS1="\[\033[1;31m\]\u\[\033[1;33m\]@\[\033[1;34m\]fast-data-dev \[\033[1;
 source /usr/share/bash-completion/bash_completion
 source /opt/landoop/tools/share/kafka-autocomplete/kafka
 alias ls='ls --color=auto'
+
+# set env variables and set defaults
+WEB_PORT=${WEB_PORT:-3030}
+ZK_PORT=${ZK_PORT:-2181}
+DEBUG=${DEBUG:-0}
+
+# check the status of zookeeper to provided $ZK_PORT
+ZK_STATUS="$(echo ruok | nc localhost $ZK_PORT | grep imok)"
+
+# Preconfigure lenses-cli
+for ((i=0;i<60;i++)); do
+    sleep 1
+    if [[  -n "$ZK_STATUS" ]]; then
+        if [[ ! -f $HOME/.lenses/lenses-cli.yml ]] && [[ -n $USER ]] && [[ -n $PASSWORD ]]; then
+            echo -e "lenses-cli configured"
+            lenses-cli configure --debug=$DEBUG --user=$USER  --pass=$PASSWORD --host=http://127.0.0.1:${WEB_PORT}
+        fi
+        break
+    fi
+done

--- a/filesystem/usr/local/share/landoop/etc/bashrc
+++ b/filesystem/usr/local/share/landoop/etc/bashrc
@@ -9,9 +9,6 @@ ZK_PORT=${ZK_PORT:-2181}
 USER=${USER:-admin}
 LEN_PASSWORD=${PASSWORD:-admin}
 
-# check the status of zookeeper to provided $ZK_PORT
-ZK_STATUS="$(echo ruok | nc localhost $ZK_PORT | grep imok)"
-
 # Preconfigure lenses-cli
 if echo ruok | nc localhost $ZK_PORT | grep -sq imok; then
         if [[ ! -f $HOME/.lenses/lenses-cli.yml ]]; then


### PR DESCRIPTION
Automatic configuration first checks if zookeeper is up and running and doesn't run in an
error state. If environment variables for user and passwords have been provided then the
`lense-cli` is auto-configured with these credentials. Same if you pass `WEB_PORT`, `DEBUG`
variables, to connect to API with the provided port and debug the usage respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/fast-data-dev/78)
<!-- Reviewable:end -->
