### PR TITLE
fixed data generators to work with new jmx and log for option structure

### DIFF
--- a/filesystem/usr/local/share/landoop/sample-data/put.sh
+++ b/filesystem/usr/local/share/landoop/sample-data/put.sh
@@ -23,6 +23,7 @@ done
 for key in 0 1 4 5; do
     unset SCHEMA_REGISTRY_OPTS
     unset SCHEMA_REGISTRY_JMX_OPTS
+    unset SCHEMA_REGISTRY_LOG4J_OPTS
     /usr/local/bin/normcat -r 5000 "${DATA[key]}" | \
         kafka-avro-console-producer \
             --broker-list ${GENERATOR_BROKER}:${BROKER_PORT} \
@@ -38,6 +39,7 @@ done
 for key in 2; do
     unset SCHEMA_REGISTRY_OPTS
     unset SCHEMA_REGISTRY_JMX_OPTS
+    unset SCHEMA_REGISTRY_LOG4J_OPTS
     /usr/local/bin/normcat -r 5000 "${DATA[key]}" | \
         kafka-avro-console-producer \
             --broker-list ${GENERATOR_BROKER}:${BROKER_PORT} \
@@ -51,6 +53,7 @@ done
 for key in 3; do
     unset KAFKA_OPTS
     unset KAFKA_JMX_OPTS
+    unset KAFKA_LOG4J_OPTS
     /usr/local/bin/normcat -r 5000 "${DATA[key]}" | \
         sed -r -e 's/([A-Z0-9-]*):/{"serial_number":"\1"}#/' | \
         kafka-console-producer \

--- a/filesystem/usr/local/share/landoop/sample-data/running-ais.sh
+++ b/filesystem/usr/local/share/landoop/sample-data/running-ais.sh
@@ -26,6 +26,7 @@ done
 for key in 0; do
     unset SCHEMA_REGISTRY_OPTS
     unset SCHEMA_REGISTRY_JMX_OPTS
+    unset SCHEMA_REGISTRY_LOG4J_OPTS
     /usr/local/bin/normcat -r "${RATES[key]}" -j "${JITTER[key]}" -p "${PERIOD[key]}" -c -v "${DATA[key]}" | \
         SCHEMA_REGISTRY_HEAP_OPTS="-Xmx50m" kafka-avro-console-producer \
             --broker-list ${GENERATOR_BROKER}:${BROKER_PORT} \

--- a/filesystem/usr/local/share/landoop/sample-data/running-reddit.sh
+++ b/filesystem/usr/local/share/landoop/sample-data/running-reddit.sh
@@ -26,6 +26,7 @@ done
 for key in 1; do
     unset SCHEMA_REGISTRY_OPTS
     unset SCHEMA_REGISTRY_JMX_OPTS
+    unset SCHEMA_REGISTRY_LOG4J_OPTS
     /usr/local/bin/normcat -r "${RATES[key]}" -j "${JITTER[key]}" -p "${PERIOD[key]}" -c -v "${DATA[key]}" | \
         SCHEMA_REGISTRY_HEAP_OPTS="-Xmx50m" kafka-avro-console-producer \
             --broker-list ${GENERATOR_BROKER}:${BROKER_PORT} \

--- a/filesystem/usr/local/share/landoop/sample-data/running-taxis.sh
+++ b/filesystem/usr/local/share/landoop/sample-data/running-taxis.sh
@@ -26,6 +26,7 @@ done
 for key in 2; do
     unset SCHEMA_REGISTRY_OPTS
     unset SCHEMA_REGISTRY_JMX_OPTS
+    unset SCHEMA_REGISTRY_LOG4J_OPTS
     /usr/local/bin/normcat -r "${RATES[key]}" -j "${JITTER[key]}" -p "${PERIOD[key]}" -c -v "${DATA[key]}" | \
         SCHEMA_REGISTRY_HEAP_OPTS="-Xmx50m" kafka-avro-console-producer \
             --broker-list ${GENERATOR_BROKER}:${BROKER_PORT} \

--- a/filesystem/usr/local/share/landoop/sample-data/running-telecom-italia.sh
+++ b/filesystem/usr/local/share/landoop/sample-data/running-telecom-italia.sh
@@ -27,6 +27,7 @@ done
 for key in 5; do
     unset SCHEMA_REGISTRY_OPTS
     unset SCHEMA_REGISTRY_JMX_OPTS
+    unset SCHEMA_REGISTRY_LOG4J_OPTS
     /usr/local/bin/normcat -v "${DATA[key]}" | \
         SCHEMA_REGISTRY_HEAP_OPTS="-Xmx50m" kafka-avro-console-producer \
             --broker-list ${GENERATOR_BROKER}:${BROKER_PORT} \
@@ -42,6 +43,7 @@ done
 for key in 4; do
     unset SCHEMA_REGISTRY_OPTS
     unset SCHEMA_REGISTRY_JMX_OPTS
+    unset SCHEMA_REGISTRY_LOG4J_OPTS
     /usr/local/bin/normcat -r "${RATES[key]}" -j "${JITTER[key]}" -p "${PERIOD[key]}" -c -v "${DATA[key]}" | \
         SCHEMA_REGISTRY_HEAP_OPTS="-Xmx50m" kafka-avro-console-producer \
             --broker-list ${GENERATOR_BROKER}:${BROKER_PORT} \


### PR DESCRIPTION
Removed SCHEMA_REGISTRY_LOG4J_OPTS from avro data generators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/fast-data-dev/94)
<!-- Reviewable:end -->
