### PR TITLE
Add the SSL listener to the ADV_HOST when ENABLE_SSL=1

### DIFF
--- a/setup-and-run.sh
+++ b/setup-and-run.sh
@@ -203,6 +203,10 @@ if [[ -n ${ADV_HOST} ]]; then
     echo -e "\e[92mSetting advertised host to \e[96m${ADV_HOST}\e[34m\e[92m.\e[34m"
     if [[ -z ${KAFKA_ADVERTISED_LISTENERS} ]]; then
         export KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://${ADV_HOST}:${BROKER_PORT}"
+        # If SSL is enabled we need to know if we should update the advertised.listeners
+        TMP_ADV_LISTENERS_SET=true
+    else
+        TMP_ADV_LISTENERS_SET=false
     fi
     if [[ -z $CONNECT_REST_ADVERTISED_HOST_NAME ]]; then
         export CONNECT_REST_ADVERTISED_HOST_NAME=${ADV_HOST}
@@ -416,7 +420,7 @@ ssl.truststore.type=JKS
 EOF
     sed -r -e "s|^(listeners=.*)|\1,SSL://:${BROKER_SSL_PORT}|" \
         -i /var/run/broker/server.properties
-    if [[ -n ${ADV_HOST} ]] && [[ -z ${KAFKA_ADVERTISED_LISTENERS} ]]; then
+    if [[ -n ${ADV_HOST} ]] && [[ $TMP_ADV_LISTENERS_SET =~ $TRUE_REG ]]; then
         sed -r \
             -e "s|^(advertised.listeners=.*)|\1,SSL://${ADV_HOST}:${BROKER_SSL_PORT}|" \
             -i /var/run/broker/server.properties


### PR DESCRIPTION
When both the ADV_HOST and ENABLE_SSL parameters were set the
server.properties file was missing the SSL advertised host.

Issue: SRE-991

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/fast-data-dev/117)
<!-- Reviewable:end -->
