### PR TITLE
Add a custom page for 502 bad gateway till Lenses run

### DIFF
--- a/filesystem/usr/local/share/landoop/etc/Caddyfile
+++ b/filesystem/usr/local/share/landoop/etc/Caddyfile
@@ -2,6 +2,9 @@
   tls off
   log stdout
   errors stdout
+  errors {
+    502 /var/www/custom_502.html
+  }
   proxy /api localhost:$LENSES_PORT {
     websocket
   }

--- a/filesystem/usr/local/share/landoop/html-errors/custom_502.html
+++ b/filesystem/usr/local/share/landoop/html-errors/custom_502.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    
+    <script type = "text/JavaScript">
+        <!--
+          function AutoRefresh( t ) {
+              setTimeout("location.reload(true);", t);
+          }
+        //-->
+    </script>
+    
+  </head>
+  
+  <body onload = "JavaScript:AutoRefresh(5000);">
+    <p>Lenses is loading...</p>
+    </br>
+    <p>This page will refresh every 5 seconds.</p>
+  </body>
+</html>
+   

--- a/setup-and-run.sh
+++ b/setup-and-run.sh
@@ -237,8 +237,9 @@ sed -e "s/3030/$WEB_PORT/" \
     -i /var/run/coyote/simple-integration-tests.yml
 
 # Copy other templated files (caddy, logs-to-kafka, env.js)
-envsubst < /usr/local/share/landoop/etc/Caddyfile               > /var/run/caddy/Caddyfile
-envsubst < /usr/local/share/landoop/etc/fast-data-dev-ui/env.js > /var/www/env.js
+envsubst < /usr/local/share/landoop/etc/Caddyfile                   > /var/run/caddy/Caddyfile
+envsubst < /usr/local/share/landoop/etc/fast-data-dev-ui/env.js     > /var/www/env.js
+envsubst < /usr/local/share/landoop/html-errors/custom_502.html > /var/www/custom_502.html
 
 # Set ADV_HOST if needed
 if [[ -n ${ADV_HOST} ]]; then


### PR DESCRIPTION
A feedback given that people ignore the message in the docker run logs
and when they open localhost:3030 page they see a 502 bad gateway which
makes them to understand that Lenses failed to run.

Custom error page with autorefresh every 5s for 502. May later we need
to have a status dashboard to show that all services are up and running.

Issue: FEED-68