### PR TITLE
FEATURE: add possibility to create user-defined kafka topics on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,26 +112,27 @@ via environment variables.
 
 #### fast-data-dev / kafka-lenses-dev advanced configuration
 
- Optional Parameters              | Description
---------------------------------- | ------------------------------------------------------------------------------------------------------------
- `CONNECT_HEAP=3G`                | Configure the maximum (`-Xmx`) heap size allocated to Kafka Connect. Useful when you want to start many connectors.
- `<SERVICE>_PORT=<PORT>`          | Custom port `<PORT>` for service, `0` will disable it. `<SERVICE>` one of `ZK`, `BROKER`, `BROKER_SSL`, `REGISTRY`, `REST`, `CONNECT`.
- `<SERVICE>_JMX_PORT=<PORT>`      | Custom JMX port `<PORT>` for service, `0` will disable it. `<SERVICE>` one of `ZK`, `BROKER`, `BROKER_SSL`, `REGISTRY`, `REST`, `CONNECT`.
- `USER=username`                  | Run in combination with `PASSWORD` to specify the username to use on basic auth.
- `PASSWORD=password`              | Protect the fast-data-dev UI when running publicly. If `USER` is not set, the default username is `kafka`.
- `SAMPLEDATA=0`                   | Do not create topics with sample avro and json records; (e.g do not create topics `sea_vessel_position_reports`, `reddit_posts`).
- `RUNNING_SAMPLEDATA=1`           | In the sample topics send a continuous (yet very low) flow of messages, so you can develop against live data.
- `RUNTESTS=0`                     | Disable the (coyote) integration tests from running when container starts.
- `FORWARDLOGS=0`                  | Disable running the file source connector that brings broker logs into a Kafka topic.
- `RUN_AS_ROOT=1`                  | Run kafka as `root` user - useful to i.e. test HDFS connector.
- `DISABLE_JMX=1`                  | Disable JMX - enabled by default on ports 9581 - 9585. You may also disable it individually for services.
- `ENABLE_SSL=1`                   | Generate a CA, key-certificate pairs and enable a SSL port on the broker.
- `SSL_EXTRA_HOSTS=IP1,host2`      | If SSL is enabled, extra hostnames and IP addresses to include to the broker certificate.
- `CONNECTORS=<CONNECTOR>[,<CON2>]`| Explicitly set which connectors* will be enabled. E.g `hbase`, `elastic` (Stream Reactor version)
- `DISABLE=<CONNECTOR>[,<CON2>]`   | Disable one or more connectors*. E.g `hbase`, `elastic` (Stream Reactor version), `elasticsearch` (Confluent version)
- `BROWSECONFIGS=1`                | Expose service configuration in the UI. Useful to see how Kafka is setup.
- `DEBUG=1`                        | Print stdout and stderr of all processes to container's stdout. Useful for debugging early container exits.
- `SUPERVISORWEB=1`                | Enable supervisor web interface on port 9001 (adjust via `SUPERVISORWEB_PORT`) in order to control services, run `tail -f`, etc.
+ Optional Parameters                 | Description
+------------------------------------ | ------------------------------------------------------------------------------------------------------------
+ `CONNECT_HEAP=3G`                   | Configure the maximum (`-Xmx`) heap size allocated to Kafka Connect. Useful when you want to start many connectors.
+ `<SERVICE>_PORT=<PORT>`             | Custom port `<PORT>` for service, `0` will disable it. `<SERVICE>` one of `ZK`, `BROKER`, `BROKER_SSL`, `REGISTRY`, `REST`, `CONNECT`.
+ `<SERVICE>_JMX_PORT=<PORT>`         | Custom JMX port `<PORT>` for service, `0` will disable it. `<SERVICE>` one of `ZK`, `BROKER`, `BROKER_SSL`, `REGISTRY`, `REST`, `CONNECT`.
+ `USER=username`                     | Run in combination with `PASSWORD` to specify the username to use on basic auth.
+ `PASSWORD=password`                 | Protect the fast-data-dev UI when running publicly. If `USER` is not set, the default username is `kafka`.
+ `KAFKA_CREATE_TOPICS=topic1,topic2` | Creates user-defined topics on startup. Topics are expressed as following: `name:partitions:replicas:cleanup.policy`. E.g `meteo:3:1`
+ `SAMPLEDATA=0`                      | Do not create topics with sample avro and json records; (e.g do not create topics `sea_vessel_position_reports`, `reddit_posts`).
+ `RUNNING_SAMPLEDATA=1`              | In the sample topics send a continuous (yet very low) flow of messages, so you can develop against live data.
+ `RUNTESTS=0`                        | Disable the (coyote) integration tests from running when container starts.
+ `FORWARDLOGS=0`                     | Disable running the file source connector that brings broker logs into a Kafka topic.
+ `RUN_AS_ROOT=1`                     | Run kafka as `root` user - useful to i.e. test HDFS connector.
+ `DISABLE_JMX=1`                     | Disable JMX - enabled by default on ports 9581 - 9585. You may also disable it individually for services.
+ `ENABLE_SSL=1`                      | Generate a CA, key-certificate pairs and enable a SSL port on the broker.
+ `SSL_EXTRA_HOSTS=IP1,host2`         | If SSL is enabled, extra hostnames and IP addresses to include to the broker certificate.
+ `CONNECTORS=<CONNECTOR>[,<CON2>]`   | Explicitly set which connectors* will be enabled. E.g `hbase`, `elastic` (Stream Reactor version)
+ `DISABLE=<CONNECTOR>[,<CON2>]`      | Disable one or more connectors*. E.g `hbase`, `elastic` (Stream Reactor version), `elasticsearch` (Confluent version)
+ `BROWSECONFIGS=1`                   | Expose service configuration in the UI. Useful to see how Kafka is setup.
+ `DEBUG=1`                           | Print stdout and stderr of all processes to container's stdout. Useful for debugging early container exits.
+ `SUPERVISORWEB=1`                   | Enable supervisor web interface on port 9001 (adjust via `SUPERVISORWEB_PORT`) in order to control services, run `tail -f`, etc.
 
 *Available connectors are: azure-documentdb, blockchain, bloomberg, cassandra,
 coap, druid, elastic, elastic5, ftp, hazelcast, hbase, influxdb, jms, kudu,

--- a/filesystem/usr/local/bin/create-topics.sh
+++ b/filesystem/usr/local/bin/create-topics.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+##
+# Two new environment variables:
+#   KAFKA_CREATE_TOPICS
+#   KAFKA_CREATE_TOPICS_SEPARATOR
+
+if [[ -z "$KAFKA_CREATE_TOPICS" ]]; then
+    exit 0
+fi
+
+# Expected format:
+#   name:partitions:replicas:cleanup.policy
+IFS="${KAFKA_CREATE_TOPICS_SEPARATOR-,}"; for topicToCreate in $KAFKA_CREATE_TOPICS; do
+    echo "Creating topic: $topicToCreate"
+
+    IFS=':' read -r -a topicConfig <<< "$topicToCreate"
+    config=
+    if [ -n "${topicConfig[3]}" ]; then
+        config="--config=cleanup.policy=${topicConfig[3]}"
+    fi
+
+    COMMAND="/opt/landoop/kafka/bin/kafka-topics \\
+        --create \\
+        --zookeeper ${KAFKA_ZOOKEEPER_CONNECT} \\
+        --topic ${topicConfig[0]} \\
+        --partitions ${topicConfig[1]} \\
+        --replication-factor ${topicConfig[2]} \\
+        ${config}"
+    eval "${COMMAND}"
+done
+
+wait

--- a/filesystem/usr/local/share/landoop/etc/supervisord.templates.d/09-create-topics.conf
+++ b/filesystem/usr/local/share/landoop/etc/supervisord.templates.d/09-create-topics.conf
@@ -1,0 +1,6 @@
+[program:create-topics]
+user=nobody
+command=bash -c 'eval $WAIT_SCRIPT_REGISTRY; exec /usr/local/bin/create-topics.sh'
+redirect_stderr=true
+stdout_logfile=/var/log/create-topics.log
+startretries=5


### PR DESCRIPTION
The goal of that feature is to add possibility for user of image to define Kafka topics that will be created on startup. It's inspired by wurstmeister/kafka-docker.
https://github.com/wurstmeister/kafka-docker/blob/master/create-topics.sh