### PR TITLE
Allow to configure schema registry with basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ via environment variables.
  `CONNECT_HEAP=3G`                | Configure the maximum (`-Xmx`) heap size allocated to Kafka Connect. Useful when you want to start many connectors.
  `<SERVICE>_PORT=<PORT>`          | Custom port `<PORT>` for service, `0` will disable it. `<SERVICE>` one of `ZK`, `BROKER`, `BROKER_SSL`, `REGISTRY`, `REST`, `CONNECT`.
  `<SERVICE>_JMX_PORT=<PORT>`      | Custom JMX port `<PORT>` for service, `0` will disable it. `<SERVICE>` one of `ZK`, `BROKER`, `BROKER_SSL`, `REGISTRY`, `REST`, `CONNECT`.
+ `REGISTRY_BASIC_AUTH=1`          | Configures Schema Registry with basic auth. Username and password will be hardcoded to `admin:admin`. 
  `USER=username`                  | Run in combination with `PASSWORD` to specify the username to use on basic auth.
  `PASSWORD=password`              | Protect the fast-data-dev UI when running publicly. If `USER` is not set, the default username is `kafka`.
  `SAMPLEDATA=0`                   | Do not create topics with sample avro and json records; (e.g do not create topics `sea_vessel_position_reports`, `reddit_posts`).

--- a/filesystem/usr/local/share/landoop/etc/supervisord.templates.d/03-schema-registry.conf
+++ b/filesystem/usr/local/share/landoop/etc/supervisord.templates.d/03-schema-registry.conf
@@ -1,6 +1,6 @@
 [program:schema-registry]
 user=nobody
-environment=JMX_PORT=$REGISTRY_JMX_PORT
+environment=JMX_PORT="$REGISTRY_JMX_PORT",SCHEMA_REGISTRY_OPTS="$REGISTRY_OPTS"
 command=bash -c 'eval $WAIT_SCRIPT_REGISTRY; exec /opt/landoop/kafka/bin/schema-registry-start /var/run/schema-registry/schema-registry.properties'
 redirect_stderr=true
 stdout_logfile=/var/log/schema-registry.log

--- a/setup-and-run.sh
+++ b/setup-and-run.sh
@@ -108,6 +108,11 @@ export SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_ORIGIN=${SCHEMA_REGISTRY_ACCESS_CONT
 export SCHEMA_REGISTRY_JMX_OPTS=${SCHEMA_REGISTRY_JMX_OPTS:--Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Djava.rmi.server.hostname=$ADV_HOST_JMX -Dcom.sun.management.jmxremote.rmi.port=$REGISTRY_JMX_PORT}
 export SCHEMA_REGISTRY_LOG4J_OPTS=${SCHEMA_REGISTRY_JMX_OPTS:--Dlog4j.configuration=file:/var/run/schema-registry/log4j.properties}
 
+if [[ -n "$REGISTRY_BASIC_AUTH" ]]; then
+  export REGISTRY_JAAS_CONFIG="/var/run/schema-registry/jaas_config"
+  export REGISTRY_OPTS="-Djava.security.auth.login.config=$REGISTRY_JAAS_CONFIG"
+fi
+
 # Set env vars for Kafka Connect Distributed
 export CONNECT_BOOTSTRAP_SERVERS=${CONNECT_BOOTSTRAP_SERVERS:-PLAINTEXT://127.0.0.1:$BROKER_PORT}
 export CONNECT_GROUP_ID=${CONNECT_GROUP_ID:-connect-fast-data}


### PR DESCRIPTION
Introduce the `REGISTRY_BASIC_AUTH` env variable allowing to configure SR with basic auth. At this stage, we do not parameterise the username/password but simply hardcode it to a standard `admin:admin`.

*discussion point:* should we also percolate this value to the Kafka configuration (or any other relevant components), so that it will play well with the everything else? 