### PR TITLE
Update Caddy github URL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -364,7 +364,7 @@ WORKDIR /
 #            https://github.com/sgerrand/alpine-pkg-glibc
 # caddy    : an excellent web server we use to serve fast-data-dev UI, proxy various REST
 #            endpoints, etc
-#            https://github.com/mholt/caddy
+#            https://github.com/caddyserver/caddy
 ARG CHECKPORT_URL="https://gitlab.com/andmarios/checkport/uploads/3903dcaeae16cd2d6156213d22f23509/checkport"
 ARG QUICKCERT_URL="https://github.com/andmarios/quickcert/releases/download/1.0/quickcert-1.0-linux-amd64-alpine"
 ARG GLIBC_INST_VERSION="2.32-r0"

--- a/Dockerfile-singlestage
+++ b/Dockerfile-singlestage
@@ -47,11 +47,11 @@ RUN wget "$FDD_LKD_URL" -O /lkd.tgz \
 #            https://github.com/sgerrand/alpine-pkg-glibc
 # caddy    : an excellent web server we use to serve fast-data-dev UI, proxy various REST
 #            endpoints, etc
-#            https://github.com/mholt/caddy
+#            https://github.com/caddyserver/caddy
 ARG CHECKPORT_URL="https://gitlab.com/andmarios/checkport/uploads/3903dcaeae16cd2d6156213d22f23509/checkport"
 ARG QUICKCERT_URL="https://github.com/andmarios/quickcert/releases/download/1.0/quickcert-1.0-linux-amd64-alpine"
 ARG GLIBC_INST_VERSION="2.27-r0"
-ARG CADDY_URL=https://github.com/mholt/caddy/releases/download/v0.10.10/caddy_v0.10.10_linux_amd64.tar.gz
+ARG CADDY_URL=https://github.com/caddyserver/caddy/releases/download/v0.10.10/caddy_v0.10.10_linux_amd64.tar.gz
 RUN wget "$CHECKPORT_URL" -O /usr/local/bin/checkport \
     && wget "$QUICKCERT_URL" -O /usr/local/bin/quickcert \
     && chmod 0755 /usr/local/bin/quickcert /usr/local/bin/checkport \


### PR DESCRIPTION
Same change with https://github.com/lensesio/kafka-connect-ui/pull/112.

Replaced https://github.com/mholt/caddy/releases/download/v0.10.10/caddy_v0.10.10_linux_amd64.tar.gz with https://github.com/caddyserver/caddy/releases/download/v0.10.10/caddy_v0.10.10_linux_amd64.tar.gz. 

It was updated once before like below:
https://github.com/lensesio/fast-data-dev/blob/e4e37ea71c9af8e052c4158568bc16200fde5995/Dockerfile#L371