### PR TITLE
Changes to support arm64 (and Apple M1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -371,9 +371,27 @@ WORKDIR /
 #            endpoints, etc
 #            https://github.com/mholt/caddy
 ARG GLIBC_INST_VERSION="2.32-r0"
-ARG CADDY_URL=https://github.com/caddyserver/caddy/releases/download/v0.11.5/caddy_v0.11.5_linux_arm64.tar.gz
-ARG GOTTY_URL=https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_arm.tar.gz
-RUN wget "$CADDY_URL" -O /caddy.tgz \
+ARG CADDY_URL_AMD64=https://github.com/caddyserver/caddy/releases/download/v0.11.5/caddy_v0.11.5_linux_amd64.tar.gz
+ARG GOTTY_URL_AMD64=https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_amd64.tar.gz
+ARG CADDY_URL_ARM64=https://github.com/caddyserver/caddy/releases/download/v0.11.5/caddy_v0.11.5_linux_arm64.tar.gz
+ARG GOTTY_URL_ARM64=https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_arm.tar.gz
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    	dir=/usr/local/src; \
+    	CADDY_URL=; \
+    	GOTTY_URL=; \
+    	case "${dpkgArch##*-}" in \
+    		'amd64') \
+    			CADDY_URL="$CADDY_URL_AMD64"; \
+    			GOTTY_URL="$GOTTY_URL_AMD64"; \
+    			;; \
+    		'arm64') \
+    			CADDY_URL="$CADDY_URL_ARM64"; \
+    			GOTTY_URL="$GOTTY_URL_ARM64"; \
+    			;; \
+    		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
+    	esac; \
+    wget "$CADDY_URL" -O /caddy.tgz \
     && mkdir -p /opt/caddy \
     && tar xzf /caddy.tgz -C /opt/caddy \
     && rm -f /caddy.tgz \

--- a/README.md
+++ b/README.md
@@ -462,3 +462,16 @@ environment variable:
 JMX ports are hardcoded to `9581` for the broker, `9582` for schema registry,
 `9583` for REST proxy and `9584` for connect distributed. Zookeeper is exposed
 at `9585`.
+
+## Development Notes
+
+**NOTE**: Not sure where this would go in an accepted PR.
+
+Building a multiple-architecture image requires using the Docker `buildx` plugin:
+
+```shell
+docker buildx create --name builder-fast-data-dev
+docker buildx build --platform linux/amd64,linux/arm64 \
+   --tag your-docker-repo/fast-data-dev:latest \
+   --pull --push --builder builder-fast-data-dev .
+```


### PR DESCRIPTION
Building off of great work by @faberchri, I modified the `caddy` and `gotty` installs to work for both `arm64` and `amd64`.  

The end of the `README.md` includes instructions on how to build the image using `docker buildx`.  Not sure where this should actually go, but happy to move it elsewhere.

I also published the image to https://hub.docker.com/r/dougdonohoe/fast-data-dev.

```
docker pull dougdonohoe/fast-data-dev
```