### PR TITLE
#180 SSL example QuickCert URL fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -365,7 +365,7 @@ WORKDIR /
 #            endpoints, etc
 #            https://github.com/mholt/caddy
 ARG CHECKPORT_URL="https://gitlab.com/andmarios/checkport/uploads/3903dcaeae16cd2d6156213d22f23509/checkport"
-ARG QUICKCERT_URL="https://github.com/andmarios/quickcert/releases/download/1.0/quickcert-1.0-linux-amd64-alpine"
+ARG QUICKCERT_URL="https://github.com/andmarios/quickcert/releases/download/1.1/quickcert-1.1-linux-amd64"
 ARG GLIBC_INST_VERSION="2.32-r0"
 ARG CADDY_URL=https://github.com/caddyserver/caddy/releases/download/v0.11.5/caddy_v0.11.5_linux_amd64.tar.gz
 ARG GOTTY_URL=https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_amd64.tar.gz

--- a/Dockerfile-singlestage
+++ b/Dockerfile-singlestage
@@ -49,7 +49,7 @@ RUN wget "$FDD_LKD_URL" -O /lkd.tgz \
 #            endpoints, etc
 #            https://github.com/mholt/caddy
 ARG CHECKPORT_URL="https://gitlab.com/andmarios/checkport/uploads/3903dcaeae16cd2d6156213d22f23509/checkport"
-ARG QUICKCERT_URL="https://github.com/andmarios/quickcert/releases/download/1.0/quickcert-1.0-linux-amd64-alpine"
+ARG QUICKCERT_URL="https://github.com/andmarios/quickcert/releases/download/1.1/quickcert-1.1-linux-amd64"
 ARG GLIBC_INST_VERSION="2.27-r0"
 ARG CADDY_URL=https://github.com/mholt/caddy/releases/download/v0.10.10/caddy_v0.10.10_linux_amd64.tar.gz
 RUN wget "$CHECKPORT_URL" -O /usr/local/bin/checkport \


### PR DESCRIPTION
As reported in issue [180](https://github.com/lensesio/fast-data-dev/issues/180) the [SSL](https://github.com/lensesio/fast-data-dev#enable-ssl-on-broker) example is currently not working.

This is a fix to change the QUICKCERT_URL default ARG location.

Fixes #180 