### PR TITLE
Enables kafka-connect REST API to listen on specified port

### DIFF
--- a/setup-and-run.sh
+++ b/setup-and-run.sh
@@ -224,6 +224,10 @@ sed -e "s/3030/$WEB_PORT/" \
     -e "s/8083/$CONNECT_PORT/" \
     -i /var/run/coyote/simple-integration-tests.yml
 
+
+# Fix Connect REST API listener
+echo "listeners=http://0.0.0.0:$CONNECT_PORT" >>  /var/run/connect/connect-avro-distributed.properties
+
 # Copy other templated files (caddy, logs-to-kafka, env.js)
 envsubst < /usr/local/share/lensesio/etc/Caddyfile               > /var/run/caddy/Caddyfile
 envsubst < /usr/local/share/lensesio/etc/fast-data-dev-ui/env.js > /var/www/env.js


### PR DESCRIPTION
By default the Kafka Connect REST API listens on port 8083. According to the documentation, the port should be configurable by specifying CONNECT_REST_PORT, but for a reason I could not identify this environment variable is not respected by the running process. The server process that runs for Kafka Connect will only be available on port 8083 regardless of this environment variable.

Attempting to set CONNECT_PORT or CONNECT_REST_PORT in the container environment variables causes all dependent services and HTTP connections to point to the wrong port, because these processes respect the environment variable, but the actual service continues to run on port 8083.

After digging through online documentation I found the configuration property that specifies the REST API listeners.

https://docs.confluent.io/platform/current/connect/security.html#connect-rest-api-http

This commit appends the listener interface and port to the connect-avro-distributed.properties file.


To test the issue without this change, attempt to run the container by specifying `-e CONNECT_PORT=4004` . After waiting an appropriate amount of time, it can be observed that no service ever listens on 4004 and inspecting the ports it can be observed that the kafka-connect service continues to listen on port 8083 despite the environment variable being specified.

After this change, the service will begin to listen on the specified port.


Author's note: I'm unsure if modifying this file in the way I've done is the preferred approach by the primary contributors. This PR is a gift of work, and I'm not funded to support in any way beyond this, so if the PR is unacceptable or needs modifications, I probably won't be able to support.